### PR TITLE
fix code changes - register

### DIFF
--- a/register.php
+++ b/register.php
@@ -8,12 +8,6 @@ require_once __DIR__ . '/classes/User.php';
 // ==== SECURE SESSION START ====
 secureSessionStart();
 
-// ==== SESSION MESSAGE DISPLAY HANDLERS ====
-$errors = $_SESSION['register_errors'] ?? [];
-$success = $_SESSION['register_success'] ?? [];
-
-unset($_SESSION['register_errors'], $_SESSION['register_success']);
-
 try {
     $pdo = Database::getInstance();
     $user = new User($pdo);


### PR DESCRIPTION
When the form is submitted, you store messages in the session and redirect.

On the redirected GET request, you need to read and clear messages exactly once so they can be displayed.

Clearing them earlier (at the top) means when you try to display them, they are already gone.

